### PR TITLE
TECH-3595 - Setting correct CPU/RAM requests/limits

### DIFF
--- a/deploy/prod/cla-assistant.yaml
+++ b/deploy/prod/cla-assistant.yaml
@@ -23,11 +23,11 @@ podAnnotations:
   reloader.stakater.com/auto: "true"
 resources:
   limits:
-    cpu: 2
-    memory: 4096Mi
+    cpu: 0.3
+    memory: 512Mi
   requests:
-    cpu: 250m
-    memory: 256Mi
+    cpu: 0.05
+    memory: 128Mi
 autoscaling:
   enabled: true
   minReplicas: 1


### PR DESCRIPTION
:chart_with_upwards_trend: :chart_with_upwards_trend: :chart_with_upwards_trend: 

Current average (12h) usage is:
**CPU**: 0.0003
**RAM**: 78.80 MB