### PR TITLE
TECH-4258 - Update resources

### DIFF
--- a/deploy/prod/cla-assistant.yaml
+++ b/deploy/prod/cla-assistant.yaml
@@ -23,15 +23,14 @@ podAnnotations:
   reloader.stakater.com/auto: "true"
 resources:
   limits:
-    cpu: 0.3
-    memory: 512Mi
+    memory: 192Mi
   requests:
     cpu: 0.05
     memory: 128Mi
 autoscaling:
   enabled: true
   minReplicas: 1
-  maxReplicas: 2
+  maxReplicas: 3
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 60
 env:


### PR DESCRIPTION
* Increasing `maxReplicas` to silence the alert related to `KubeHpaMaxedOut`.
* Decreasing memory limit to 192Mi, since some time ago we agreed for this limit to be 1.5x the requested value.