### PR TITLE
feat: adjust cpu request and hpa maxreplica for spike

### DIFF
--- a/deploy/prod/cla-assistant.yaml
+++ b/deploy/prod/cla-assistant.yaml
@@ -25,12 +25,12 @@ resources:
   limits:
     memory: 300Mi
   requests:
-    cpu: 0.01
+    cpu: 0.05 # Can't be too low to handle spike
     memory: 150Mi
 autoscaling:
   enabled: true
   minReplicas: 1
-  maxReplicas: 3
+  maxReplicas: 6
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 env:


### PR DESCRIPTION
The root cause for the hpa maxout is the cpu spike.
The perfect scale recommended cpu request is kind of too low - 10m.
HPA can't handle cpu spike well with such request, it needs to scale to 13 pods...
So the request has been updated and also get the maxreplica doubled for hpa
<img width="262" alt="image" src="https://github.com/user-attachments/assets/2327879f-7374-4b09-a61e-bc7c22028ef9" />
